### PR TITLE
fix: add environment variables for Storybook deployment

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -40,6 +40,10 @@ jobs:
         run: npm run build-storybook
         env:
           NODE_ENV: production
+          NEXT_PUBLIC_APP_ENV: development
+          NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder-key
+          CSRF_SECRET: placeholder-secret-for-storybook
         
       - name: Install Vercel CLI
         run: npm i -g vercel@canary


### PR DESCRIPTION
## Summary
Fixes Storybook deployment error by adding required environment variables to the workflow.

## Problem
Storybook deployment was failing with:
- `NEXT_PUBLIC_SUPABASE_ANON_KEY must be set for production environments`
- `CSRF_SECRET must be set for production environments`

## Solution
- Set `NEXT_PUBLIC_APP_ENV=development` to prevent production environment validation in Storybook
- Added placeholder environment variables for Supabase and CSRF that Storybook doesn't actually need
- Tested locally and Storybook builds successfully

## Changes
- Updated `.github/workflows/deploy-storybook.yml` with environment variables

🤖 Generated with [Claude Code](https://claude.ai/code)