### PR TITLE
fix: enable Vercel GitHub integration for automatic deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,6 +12,6 @@
     }
   },
   "github": {
-    "enabled": false
+    "enabled": true
   }
 }


### PR DESCRIPTION
## Summary
• Enable GitHub integration in vercel.json to fix automatic deployments
• Resolves issue where Vercel Build Check passed but no deployments occurred
• Now allows automatic deployments to main, staging, and develop branches

## Problem
The `vercel.json` had `"github": { "enabled": false }` which disabled automatic deployments, even though the deployment configuration was properly set up for the target branches.

## Solution
Changed `"enabled": false` to `"enabled": true` in vercel.json

## Test plan
- [x] Verify vercel.json syntax is valid
- [x] Confirm deployment targets remain: main, staging, develop
- [ ] Test automatic deployment after PR merge

🤖 Generated with [Claude Code](https://claude.ai/code)