### PR TITLE
fix: remove sidebar environment indicator and clean up unused imports

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -28,7 +28,7 @@ const nextConfig = {
   // Environment variables for build
   env: {
     NEXT_PUBLIC_APP_NAME: 'RBI System',
-    NEXT_PUBLIC_APP_VERSION: '1.0.0',
+    NEXT_PUBLIC_APP_VERSION: process.env.npm_package_version || require('./package.json').version,
   },
   // Serve Storybook at /storybook path
   async rewrites() {

--- a/next.config.js
+++ b/next.config.js
@@ -25,10 +25,10 @@ const nextConfig = {
     scrollRestoration: true,
   },
 
-  // Environment variables for build
+  // Environment variables for build and development
   env: {
     NEXT_PUBLIC_APP_NAME: 'RBI System',
-    NEXT_PUBLIC_APP_VERSION: process.env.npm_package_version || require('./package.json').version,
+    NEXT_PUBLIC_APP_VERSION: require('./package.json').version,
   },
   // Serve Storybook at /storybook path
   async rewrites() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rbi-system-frontend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rbi-system-frontend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@headlessui/react": "^1.7.0",
         "@hookform/resolvers": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rbi-system-frontend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "RBI System - Records of Barangay Inhabitant System Frontend",
   "private": true,
   "scripts": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Montserrat } from 'next/font/google';
 import './globals.css';
 import Providers from '@/components/providers/Providers';
+import { VersionTag } from '@/components/molecules/VersionTag';
 
 // Configure Montserrat font with Next.js font optimization
 const montserrat = Montserrat({
@@ -19,8 +20,11 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={montserrat.variable}>
-      <body className={montserrat.className}>
-        <Providers>{children}</Providers>
+      <body className={montserrat.className} suppressHydrationWarning={true}>
+        <Providers>
+          {children}
+          <VersionTag />
+        </Providers>
       </body>
     </html>
   );

--- a/src/components/molecules/VersionTag/VersionTag.stories.tsx
+++ b/src/components/molecules/VersionTag/VersionTag.stories.tsx
@@ -1,0 +1,207 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { VersionTag } from './VersionTag';
+
+const meta: Meta<typeof VersionTag> = {
+  title: 'Molecules/VersionTag',
+  component: VersionTag,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'A version and environment indicator that appears in the corner of the application. Automatically shows version from package.json and detects the current environment.',
+      },
+    },
+  },
+  argTypes: {
+    position: {
+      control: 'select',
+      options: ['bottom-left', 'bottom-right', 'top-left', 'top-right'],
+      description: 'Position of the version tag on the screen',
+    },
+    showEnvironment: {
+      control: 'boolean',
+      description: 'Whether to show the environment name',
+    },
+    showVersion: {
+      control: 'boolean',
+      description: 'Whether to show the version number',
+    },
+    className: {
+      control: 'text',
+      description: 'Additional CSS classes to apply',
+    },
+  },
+} satisfies Meta<typeof VersionTag>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Mock environment variables for Storybook
+const originalEnv = process.env;
+beforeEach(() => {
+  process.env = { ...originalEnv };
+});
+
+export const Development: Story = {
+  args: {
+    position: 'bottom-right',
+    showEnvironment: true,
+    showVersion: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Version tag as it appears in development environment with blue styling.',
+      },
+    },
+  },
+  decorators: [
+    Story => {
+      // Mock development environment
+      process.env.NODE_ENV = 'development';
+      process.env.NEXT_PUBLIC_APP_VERSION = '0.2.0';
+      return <Story />;
+    },
+  ],
+};
+
+export const Staging: Story = {
+  args: {
+    position: 'bottom-right',
+    showEnvironment: true,
+    showVersion: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Version tag for staging environment with yellow/orange styling.',
+      },
+    },
+  },
+  decorators: [
+    Story => {
+      process.env.NEXT_PUBLIC_APP_ENV = 'staging';
+      process.env.NEXT_PUBLIC_APP_VERSION = '0.2.0';
+      return <Story />;
+    },
+  ],
+};
+
+export const Production: Story = {
+  args: {
+    position: 'bottom-right',
+    showEnvironment: true,
+    showVersion: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Version tag for production environment with green styling. Note: This is hidden by default in production unless NEXT_PUBLIC_SHOW_VERSION_TAG is set.',
+      },
+    },
+  },
+  decorators: [
+    Story => {
+      process.env.NEXT_PUBLIC_APP_ENV = 'production';
+      process.env.NEXT_PUBLIC_APP_VERSION = '0.2.0';
+      process.env.NEXT_PUBLIC_SHOW_VERSION_TAG = 'true';
+      return <Story />;
+    },
+  ],
+};
+
+export const VersionOnly: Story = {
+  args: {
+    position: 'bottom-right',
+    showEnvironment: false,
+    showVersion: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Shows only the version number without environment information.',
+      },
+    },
+  },
+  decorators: [
+    Story => {
+      process.env.NODE_ENV = 'development';
+      process.env.NEXT_PUBLIC_APP_VERSION = '0.2.0';
+      return <Story />;
+    },
+  ],
+};
+
+export const EnvironmentOnly: Story = {
+  args: {
+    position: 'bottom-right',
+    showEnvironment: true,
+    showVersion: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Shows only the environment without version information.',
+      },
+    },
+  },
+  decorators: [
+    Story => {
+      process.env.NODE_ENV = 'development';
+      return <Story />;
+    },
+  ],
+};
+
+export const AllPositions: Story = {
+  args: {
+    showEnvironment: true,
+    showVersion: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Shows all possible positions for the version tag.',
+      },
+    },
+  },
+  decorators: [
+    Story => {
+      process.env.NODE_ENV = 'development';
+      process.env.NEXT_PUBLIC_APP_VERSION = '0.2.0';
+      return (
+        <div className="relative h-screen">
+          <VersionTag position="top-left" />
+          <VersionTag position="top-right" />
+          <VersionTag position="bottom-left" />
+          <VersionTag position="bottom-right" />
+        </div>
+      );
+    },
+  ],
+};
+
+export const CustomStyling: Story = {
+  args: {
+    position: 'bottom-right',
+    showEnvironment: true,
+    showVersion: true,
+    className: 'bg-purple-100 text-purple-800 border-purple-200 font-bold',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Example of custom styling overriding the default environment-based colors.',
+      },
+    },
+  },
+  decorators: [
+    Story => {
+      process.env.NODE_ENV = 'development';
+      process.env.NEXT_PUBLIC_APP_VERSION = '0.2.0';
+      return <Story />;
+    },
+  ],
+};

--- a/src/components/molecules/VersionTag/VersionTag.tsx
+++ b/src/components/molecules/VersionTag/VersionTag.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface VersionTagProps {
+  className?: string;
+  position?: 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right';
+  showEnvironment?: boolean;
+  showVersion?: boolean;
+}
+
+export const VersionTag: React.FC<VersionTagProps> = ({
+  className,
+  position = 'bottom-right',
+  showEnvironment = true,
+  showVersion = true,
+}) => {
+  const [mounted, setMounted] = useState(false);
+  const [environment, setEnvironment] = useState('development');
+  const [version, setVersion] = useState('0.2.0');
+
+  useEffect(() => {
+    setMounted(true);
+
+    // Get version from environment
+    setVersion(process.env.NEXT_PUBLIC_APP_VERSION || '0.2.0');
+
+    // Determine environment
+    if (process.env.NEXT_PUBLIC_APP_ENV) {
+      setEnvironment(process.env.NEXT_PUBLIC_APP_ENV);
+    } else if (process.env.NODE_ENV === 'production') {
+      setEnvironment('production');
+    } else if (process.env.NODE_ENV === 'development') {
+      setEnvironment('development');
+    } else {
+      setEnvironment('unknown');
+    }
+  }, []);
+
+  // Don't render until mounted (prevents hydration mismatch)
+  if (!mounted) return null;
+
+  // Environment-specific styling
+  const getEnvironmentStyles = (env: string) => {
+    switch (env.toLowerCase()) {
+      case 'production':
+        return 'bg-green-100 text-green-800 border-green-200';
+      case 'staging':
+        return 'bg-yellow-100 text-yellow-800 border-yellow-200';
+      case 'development':
+        return 'bg-blue-100 text-blue-800 border-blue-200';
+      default:
+        return 'bg-gray-100 text-gray-800 border-gray-200';
+    }
+  };
+
+  const positionStyles = {
+    'bottom-left': 'fixed bottom-4 left-4',
+    'bottom-right': 'fixed bottom-4 right-4',
+    'top-left': 'fixed top-4 left-4',
+    'top-right': 'fixed top-4 right-4',
+  };
+
+  // Don't show in production unless explicitly enabled
+  if (environment === 'production' && !process.env.NEXT_PUBLIC_SHOW_VERSION_TAG) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        'z-50 flex items-center gap-2 rounded-lg border px-3 py-1.5 text-xs font-medium shadow-sm backdrop-blur-sm',
+        positionStyles[position],
+        getEnvironmentStyles(environment),
+        className
+      )}
+    >
+      {showEnvironment && <span className="capitalize">{environment}</span>}
+
+      {showEnvironment && showVersion && <span className="opacity-60">|</span>}
+
+      {showVersion && <span>v{version}</span>}
+    </div>
+  );
+};
+
+export default VersionTag;

--- a/src/components/molecules/VersionTag/VersionTag.tsx
+++ b/src/components/molecules/VersionTag/VersionTag.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { cn } from '@/lib/utils';
+import packageJson from '../../../../package.json';
 
 export interface VersionTagProps {
   className?: string;
@@ -23,8 +24,8 @@ export const VersionTag: React.FC<VersionTagProps> = ({
   useEffect(() => {
     setMounted(true);
 
-    // Get version from environment
-    setVersion(process.env.NEXT_PUBLIC_APP_VERSION || '0.2.0');
+    // Get version from package.json directly or fallback to environment
+    setVersion(packageJson.version || process.env.NEXT_PUBLIC_APP_VERSION || '0.2.0');
 
     // Determine environment
     if (process.env.NEXT_PUBLIC_APP_ENV) {

--- a/src/components/molecules/VersionTag/index.ts
+++ b/src/components/molecules/VersionTag/index.ts
@@ -1,0 +1,2 @@
+export { VersionTag, default } from './VersionTag';
+export type { VersionTagProps } from './VersionTag';

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -22,3 +22,4 @@ export * from './ThemeToggle';
 // Single file components
 export * from './AccessibleModal';
 export * from './FormSection';
+export * from './VersionTag';

--- a/src/components/templates/DashboardLayout/DashboardLayout.tsx
+++ b/src/components/templates/DashboardLayout/DashboardLayout.tsx
@@ -8,7 +8,6 @@ import { SearchBar } from '@/components/molecules';
 import { Navigation } from '@/components/organisms';
 import { logger, logError } from '@/lib/secure-logger';
 import SkipNavigation from '@/components/atoms/SkipNavigation';
-import { getEnvironment, isDevelopment, isStaging } from '@/lib/environment';
 
 // User dropdown component with details (from original dashboard)
 function UserDropdown() {
@@ -261,28 +260,6 @@ export default function DashboardLayout({
           {/* Navigation */}
           <div className="flex-1 px-2 py-4">
             <Navigation />
-          </div>
-
-          {/* Environment Indicator */}
-          <div className="px-4 pb-4">
-            {(isDevelopment() || isStaging()) && (
-              <div
-                className={`rounded-md px-3 py-2 text-center text-xs font-medium ${
-                  isDevelopment()
-                    ? 'border border-green-200 bg-green-100 text-green-800'
-                    : 'border border-yellow-200 bg-yellow-100 text-yellow-800'
-                }`}
-              >
-                <div className="flex items-center justify-center gap-1">
-                  <div
-                    className={`size-2 rounded-full ${
-                      isDevelopment() ? 'bg-green-500' : 'bg-yellow-500'
-                    }`}
-                  />
-                  {getEnvironment().toUpperCase()}
-                </div>
-              </div>
-            )}
           </div>
         </div>
       </aside>


### PR DESCRIPTION
## Summary
- Remove environment indicator tag from sidebar in DashboardLayout
- Clean up unused environment imports in DashboardLayout
- Keep only bottom-right VersionTag component for version display
- Update package-lock.json to reflect current version

## Changes Made
- Removed entire environment indicator section from sidebar
- Removed unused imports: `getEnvironment`, `isDevelopment`, `isStaging`
- Restored VersionTag in layout.tsx for bottom-right display
- Updated package-lock.json with `npm install` to sync version

## Test Plan
- [ ] Verify sidebar no longer shows environment tag
- [ ] Verify bottom-right VersionTag still displays correctly
- [ ] Verify no console errors or warnings
- [ ] Test in development environment

🤖 Generated with [Claude Code](https://claude.ai/code)