### PR TITLE
fix: upgrade GitHub Actions workflows to Node.js 20

### DIFF
--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       # Advanced caching for faster builds

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       # Advanced caching for faster builds
@@ -113,7 +113,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       # Advanced caching for faster builds
@@ -212,7 +212,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       # Advanced caching for faster builds
@@ -282,7 +282,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       # Advanced caching for faster builds

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
 
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/vercel-build.yml
+++ b/.github/workflows/vercel-build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       # Advanced caching for faster builds


### PR DESCRIPTION
## Summary
- Upgrade all GitHub Actions workflows from Node.js 18 to Node.js 20
- Fixes build failures due to dependency engine requirements
- Addresses compatibility issues with modern dependencies

## Root Cause
The current GitHub Actions workflows use Node.js 18, but several key dependencies now require Node.js 20+:
- Storybook 9.x requires Node.js ≥20.0.0
- Semantic Release packages require Node.js ≥20.8.1
- lint-staged requires Node.js ≥20.17
- Various @octokit packages require Node.js ≥20

## Changes Made
- Updated `node-version` from '18' to '20' in all workflow files:
  - `.github/workflows/release.yml`
  - `.github/workflows/codeql.yml`
  - `.github/workflows/sonarcloud.yml`
  - `.github/workflows/bundle-analysis.yml`
  - `.github/workflows/vercel-build.yml`
  - `.github/workflows/code-review.yml`

## Test Plan
- [ ] Verify builds pass with Node.js 20
- [ ] Check that all dependency engine warnings are resolved
- [ ] Ensure deployment pipeline works correctly
- [ ] Validate semantic release functionality

## Impact
- ✅ Resolves build failures in GitHub Actions
- ✅ Ensures compatibility with latest dependencies
- ✅ Future-proofs the CI/CD pipeline
- ⚠️ May require updating local development environments to Node.js 20

🤖 Generated with [Claude Code](https://claude.ai/code)