### PR TITLE
fix: update Node.js engine requirement to 20.0.0 for Vercel compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "webpack-bundle-analyzer": "^4.10.2"
   },
   "engines": {
-    "node": ">=18.17.0"
+    "node": ">=20.0.0"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Summary
- Update package.json engines field from ">=18.17.0" to ">=20.0.0"
- Fixes Vercel build failures due to dependency engine requirements
- Ensures consistency between Vercel and GitHub Actions environments

## Root Cause
Vercel was using Node.js 18 by default (based on package.json engines field), but our dependencies require Node.js 20+:
- Storybook 9.x requires Node.js ≥20.0.0
- Semantic Release packages require Node.js ≥20.8.1  
- lint-staged requires Node.js ≥20.17
- Various @octokit packages require Node.js ≥20

## Changes Made
- Updated `"engines": { "node": ">=20.0.0" }` in package.json
- This will force Vercel to use Node.js 20.x for builds
- Maintains consistency with GitHub Actions workflows already updated to Node.js 20

## Test Plan
- [ ] Verify Vercel builds now use Node.js 20
- [ ] Check that dependency engine warnings are resolved in Vercel
- [ ] Ensure Next.js application builds successfully
- [ ] Validate both development and production deployments

## Impact
- ✅ Resolves Vercel build failures due to Node.js version mismatch
- ✅ Ensures compatibility with modern dependencies
- ✅ Aligns Vercel environment with GitHub Actions
- ⚠️ May require updating local development environments to Node.js 20

🤖 Generated with [Claude Code](https://claude.ai/code)