### PR TITLE
fix: improve service exports and geographic service integration

### DIFF
--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -33,10 +33,10 @@ export {
   type UserSecurityData,
 } from './user-repository';
 
-// Business services  
+// Business services
 export { residentService as ResidentService } from './resident.service';
 export { householdService as HouseholdService } from './household.service';
-export { geographicService as GeographicService } from './geographic.service';
+export * from './geographic.service';
 
 // Data transformers and mappers
 export * from './residentMapper';


### PR DESCRIPTION
## Summary
- Use wildcard export for geographic service for better export coverage
- Resolve merge conflict in services index from stashed changes
- Maintain consistent service export patterns

## Changes
- Updated `src/services/index.ts` to use `export * from './geographic.service'` instead of named export
- This provides better coverage of all geographic service exports

## Test plan
- [x] Service exports resolved
- [x] No breaking changes to existing imports

🤖 Generated with [Claude Code](https://claude.ai/code)