### PR TITLE
fix: use shell script for husky prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "deploy:test": "./scripts/quality/setup-deployment.sh test",
     "deploy:storybook": "npm run build-storybook && echo 'Storybook built - deploy via GitHub Actions or Netlify CLI'",
     "setup-secrets": "./scripts/quality/setup-secrets.sh",
-    "prepare": "node -e \"if (process.env.CI !== 'true' && process.env.VERCEL !== '1') { require('child_process').execSync('husky', { stdio: 'inherit' }) }\"",
+    "prepare": "./scripts/prepare-husky.sh || true",
     "env:check": "node -e \"console.log('✅ Environment check passed'); console.log('Node:', process.version); console.log('Platform:', process.platform);\"",
     "_comment_tiers": "=== ENVIRONMENT-BASED QUALITY TIERS ===",
     "tier1:dev": "npm run dev:check && npm run dev:test",

--- a/scripts/prepare-husky.sh
+++ b/scripts/prepare-husky.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Only run husky in local development, skip in CI/CD
+if [ "$CI" != "true" ] && [ "$VERCEL" != "1" ]; then
+  husky
+fi


### PR DESCRIPTION
## Problem
Previous fix used complex node -e script which may have issues in Vercel builds.

## Solution  
- Created simple shell script 
- Checks `CI` and `VERCEL` environment variables
- Added `|| true` fallback to prevent failures
- Much simpler and more reliable than inline node script

## Testing
- Shell script will run in local development
- Will skip in Vercel/CI environments
- Fallback ensures build won't fail even if script is missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated the dependency install “prepare” step from an inline command to a dedicated shell script for improved maintainability.
  * Preserved behavior: pre-commit hooks are set up only in local development, not during CI or on hosted deployments.
  * Added failure tolerance to avoid blocking installs if hook setup is unavailable.
  * Clarified environment checks to ensure tooling runs only when appropriate, reducing noise and setup issues for non-local environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->