### PR TITLE
fix: move Tailwind dependencies from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,10 @@
     "sharp": "^0.34.3",
     "tailwind-merge": "^3.3.1",
     "uuid": "^11.1.0",
-    "zod": "^4.1.1"
+    "zod": "^4.1.1",
+    "@tailwindcss/postcss": "^4.1.12",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^4.1.11"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.1",
@@ -142,7 +145,6 @@
     "@storybook/blocks": "^8.6.14",
     "@storybook/nextjs": "^9.1.3",
     "@supabase/supabase-js": "^2.56.0",
-    "@tailwindcss/postcss": "^4.1.12",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
@@ -177,7 +179,6 @@
     "lint-staged": "^16.1.5",
     "madge": "^8.0.0",
     "playwright": "^1.54.2",
-    "postcss": "^8.4.0",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14",
     "process": "^0.11.10",
@@ -186,7 +187,6 @@
     "sonarqube-scanner": "^4.3.0",
     "storybook": "^9.1.3",
     "stream-browserify": "^3.0.0",
-    "tailwindcss": "^4.1.11",
     "ts-node": "^10.9.2",
     "tsx": "^4.20.5",
     "typescript": "^5.0.0",


### PR DESCRIPTION
## Summary
- Moved `@tailwindcss/postcss`, `postcss`, and `tailwindcss` from devDependencies to dependencies
- This ensures Tailwind CSS is available in production builds

## Test plan
- [ ] Verify production build works correctly
- [ ] Confirm Tailwind styles are applied in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)